### PR TITLE
feature fixed

### DIFF
--- a/TabloidCLI/Repositories/DatabaseConnector.cs
+++ b/TabloidCLI/Repositories/DatabaseConnector.cs
@@ -10,8 +10,6 @@ namespace TabloidCLI.Repositories
         private readonly string _connectionString;
         protected SqlConnection Connection => new SqlConnection(_connectionString);
 
-        public string ConnectionString => _connectionString;
-
         public DatabaseConnector(string connectionString)
         {
             _connectionString = connectionString;

--- a/TabloidCLI/UserInterfaceManagers/NoteManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/NoteManager.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using TabloidCLI.Models;
 using TabloidCLI.Repositories;
 
@@ -55,8 +56,9 @@ namespace TabloidCLI.UserInterfaceManagers
 
         private void List()
         {
-            List<Note> notes = _noteRepository.GetAll();
-            foreach (Note note in notes)
+            List<Note> allNotes = _noteRepository.GetAll();
+            List<Note> filteredNotes = allNotes.Where(note => note.Post.Id == _postId).ToList();
+            foreach (Note note in filteredNotes)
             {
                 Console.WriteLine(note);
             }

--- a/TabloidCLI/UserInterfaceManagers/PostDetailManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/PostDetailManager.cs
@@ -11,6 +11,7 @@ namespace TabloidCLI.UserInterfaceManagers
         private PostRepository _postRepository;
         private TagRepository _tagRepository;
         private int _postId;
+        private string _connectionString;
 
         public PostDetailManager(IUserInterfaceManager parentUI, string connectionString, int postId)
         {
@@ -18,6 +19,7 @@ namespace TabloidCLI.UserInterfaceManagers
             _postRepository = new PostRepository(connectionString);
             _tagRepository = new TagRepository(connectionString);
             _postId = postId;
+            _connectionString = connectionString;
         }
 
         public IUserInterfaceManager Execute()
@@ -43,8 +45,7 @@ namespace TabloidCLI.UserInterfaceManagers
                 case "3":
                     //
                 case "4":
-                    NoteManagement();
-                    return this;
+                    return new NoteManager(this, _connectionString, post.Id);
                 case "0":
                     return _parentUI;
                 default:
@@ -61,10 +62,5 @@ namespace TabloidCLI.UserInterfaceManagers
             Console.WriteLine($"Publication Date: {post.PublishDateTime}");
         }
 
-        private void NoteManagement()
-        {
-            NoteManager noteManager = new NoteManager(this, _postRepository.ConnectionString, _postId);
-            noteManager.Execute();
-        }
     }
 }


### PR DESCRIPTION
## What?
Refactored note manager to be more concise. Previous behavior included listing all notes, rather than just the note connected to a particular post
## Why?
The expected behavior was not demonstrated by the feature in post-merge testing
## How?
Altered the method which listed notes by post, the method to find a note by id, etc. 
## Testing?
Tested in front of the team. All worked as expected