### PR TITLE
can view a post's tags as part of the post details viewer

### DIFF
--- a/TabloidCLI.sql
+++ b/TabloidCLI.sql
@@ -124,6 +124,10 @@ INSERT INTO Note ( Title, Content, CreateDateTime, PostId ) VALUES ('Semi-Specif
 INSERT INTO Note ( Title, Content, CreateDateTime, PostId ) VALUES ('Not Random', 'Semi-Educational', CURRENT_TIMESTAMP, 5);
 
 INSERT INTO Tag ( Name ) VALUES ( 'nerdy' );
+INSERT INTO Tag ( Name ) VALUES ( 'cool' );
+INSERT INTO Tag ( Name ) VALUES ( 'sucks' );
+INSERT INTO Tag ( Name ) VALUES ( 'great' );
+
 
 --INSERT INTO AuthorTag ( AuthorId, TagId) VALUES ( );
 

--- a/TabloidCLI/Repositories/JournalRepository.cs
+++ b/TabloidCLI/Repositories/JournalRepository.cs
@@ -43,8 +43,7 @@ namespace TabloidCLI
 
         public Journal Get(int id) 
         {
-            //finish later
-            return null;
+            throw new NotImplementedException();
         }
 
         public void Insert(Journal journal) 

--- a/TabloidCLI/Repositories/TagRepository.cs
+++ b/TabloidCLI/Repositories/TagRepository.cs
@@ -41,14 +41,40 @@ namespace TabloidCLI
             }
         }
 
-        public Tag Get(int id)
+        public Tag Get(int id) 
+        {
+            throw new NotImplementedException();
+        }
+
+        public List<Tag> GetPostTags(int postId)
         {
             using (SqlConnection conn = Connection)
             {
                 conn.Open();
                 using (SqlCommand cmd = conn.CreateCommand())
                 {
-                    return null;
+                    cmd.CommandText = @"SELECT p.id AS postId, pt.Id AS postTagId, t.Name AS tagName, t.Id as tagId
+                                        FROM Post p
+                                        JOIN PostTag pt ON p.Id = pt.PostId
+                                        JOIN Tag t ON t.Id = pt.TagId
+                                        WHERE p.id = @postId";
+                    cmd.Parameters.AddWithValue("@postId", postId);
+
+                    List<Tag> tags = new List<Tag>();
+
+                    SqlDataReader reader = cmd.ExecuteReader();
+
+                    while (reader.Read()) 
+                    {
+                        Tag tag = new Tag
+                        {
+                            Id = reader.GetInt32(reader.GetOrdinal("tagId")),
+                            Name = reader.GetString(reader.GetOrdinal("tagName"))
+                        };
+                        tags.Add(tag) ;
+                    }
+                    reader.Close();
+                    return tags;
                 }
             }
         }

--- a/TabloidCLI/UserInterfaceManagers/PostDetailManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/PostDetailManager.cs
@@ -57,6 +57,11 @@ namespace TabloidCLI.UserInterfaceManagers
         private void View()
         {
             Post post = _postRepository.Get(_postId);
+            List<Tag> matchingTags = _tagRepository.GetPostTags(_postId);
+            foreach ( Tag tag in matchingTags )
+            {
+                Console.WriteLine($"Tag: {tag.Name}");
+            }
             Console.WriteLine($"Title: {post.Title}");
             Console.WriteLine($"URL: {post.Url}");
             Console.WriteLine($"Publication Date: {post.PublishDateTime}");


### PR DESCRIPTION
## What?
Altered the post detail viewer to include any tags found attached to the post
## Why?
A post's tags are a vital detail. Users require the ability to view the posts details.
## How?
Altered the tag repository to include a method to search tags by postId. 
## Testing?
Tested in front of group. Feature worked as expected. Can test further in combination with other features